### PR TITLE
[Timestamp FIle Names] Capture all non-extension text

### DIFF
--- a/plugins/timestamp-file-names/index.js
+++ b/plugins/timestamp-file-names/index.js
@@ -8,10 +8,23 @@ export function onLoad() {
     unintercept = intercept((dispatch) => {
         if (dispatch?.type === "UPLOAD_ATTACHMENT_ADD_FILES") {
             dispatch?.files?.forEach(({ file }) => {
-                // change the filename to current timestamp
+                // change the root name of the file to current epoch time
                 Object.defineProperty(file, "name", {
                     value: file?.name?.replace(
-                        /^([^.]+)/,
+                        // capture up to amount within curly bracket quantifier
+                        new RegExp(
+                            "^(.{" +
+                            (
+                                // check if filename includes a dot
+                                file.name.includes(".") ?
+                                // if so, use its last index in the quantifier
+                                file.name.lastIndexOf(".") :
+                                // if not, use filename length in the quantifier
+                                file.name.length
+                            )
+                            + "})"
+                        ),
+                        // denote timestamp as the new value for captured text
                         Date.now().toString()
                     )
                 });


### PR DESCRIPTION
This alters the regex used for the capture to one with a dynamic quantifier.

If there is no dot in the filename, the curly bracket quantifier's value is equal to the filename's length.

If there is a dot in the filename, the curly bracket quantifier's value is equal to its last index. This will not include the dot in the capture (because the index starts at 0).